### PR TITLE
75 tests are very slow

### DIFF
--- a/configilm/extra/DataModules/BEN2_DataModule.py
+++ b/configilm/extra/DataModules/BEN2_DataModule.py
@@ -27,6 +27,7 @@ class BEN2DataModule(BENDataModule):
         shuffle=None,
         new_label_file: Union[str, Path, None] = None,
         print_infos: bool = False,
+        pin_memory: Optional[bool] = None,
         dataset_kwargs: Optional[Mapping] = None,
     ):
         """
@@ -69,6 +70,11 @@ class BEN2DataModule(BENDataModule):
 
             :Default: False
 
+        :param pin_memory: Flag if memory should be pinned for data loading. If not
+            specified set to True if cuda devices are used, else false.
+
+            :Default: None
+
         :param dataset_kwargs: Other keyword arguments to pass to the dataset during
             creation.
         """
@@ -86,6 +92,7 @@ class BEN2DataModule(BENDataModule):
             shuffle=shuffle,
             dataset_kwargs=dataset_kwargs,
             print_infos=print_infos,
+            pin_memory=pin_memory,
         )
         self.new_label_file = new_label_file
         self.print_infos = print_infos

--- a/configilm/extra/DataModules/BEN_DataModule.py
+++ b/configilm/extra/DataModules/BEN_DataModule.py
@@ -39,6 +39,7 @@ class BENDataModule(pl.LightningDataModule):
         max_img_idx=None,
         shuffle=None,
         print_infos: bool = False,
+        pin_memory: Optional[bool] = None,
         dataset_kwargs: Optional[Mapping] = None,
     ):
         """
@@ -75,6 +76,11 @@ class BENDataModule(pl.LightningDataModule):
             should be printed (e.g. number of workers detected, number of images loaded)
 
             :Default: False
+
+        :param pin_memory: Flag if memory should be pinned for data loading. If not
+            specified set to True if cuda devices are used, else false.
+
+            :Default: None
 
         :param dataset_kwargs: Other keyword arguments to pass to the dataset during
             creation.
@@ -120,6 +126,7 @@ class BENDataModule(pl.LightningDataModule):
             img_size=(self.img_size[1], self.img_size[2]), mean=ben_mean, std=ben_std
         )
         self.pin_memory = torch.cuda.device_count() > 0
+        self.pin_memory = self.pin_memory if pin_memory is None else pin_memory
 
     def setup(self, stage: Optional[str] = None) -> None:
         """

--- a/configilm/extra/DataModules/COCOQA_DataModule.py
+++ b/configilm/extra/DataModules/COCOQA_DataModule.py
@@ -32,6 +32,7 @@ class COCOQADataModule(pl.LightningDataModule):
         shuffle=None,
         tokenizer=None,
         seq_length=64,
+        pin_memory: Optional[bool] = None,
     ):
         super().__init__()
         if num_workers_dataloader is None:
@@ -77,6 +78,7 @@ class COCOQADataModule(pl.LightningDataModule):
         )
         # self.transform = None
         self.pin_memory = torch.cuda.device_count() > 0
+        self.pin_memory = self.pin_memory if pin_memory is None else pin_memory
 
     def prepare_data(self):
         pass

--- a/configilm/extra/DataModules/HRVQA_DataModule.py
+++ b/configilm/extra/DataModules/HRVQA_DataModule.py
@@ -35,7 +35,7 @@ class HRVQADataModule(pl.LightningDataModule):
         tokenizer=None,
         seq_length=32,
         selected_answers=None,
-        pin_memory=None,
+        pin_memory: Optional[bool] = None,
         test_splitting_seed=None,
         test_splitting_division=None,
         print_infos: bool = False,

--- a/configilm/extra/DataModules/RSVQAHR_DataModule.py
+++ b/configilm/extra/DataModules/RSVQAHR_DataModule.py
@@ -38,7 +38,7 @@ class RSVQAHRDataModule(pl.LightningDataModule):
         tokenizer=None,
         seq_length=32,
         selected_answers=None,
-        pin_memory=None,
+        pin_memory: Optional[bool] = None,
         use_phili_test: bool = False,
         print_infos: bool = False,
         dataset_kwargs: Optional[Mapping] = None,

--- a/configilm/extra/DataModules/RSVQAxBEN_DataModule.py
+++ b/configilm/extra/DataModules/RSVQAxBEN_DataModule.py
@@ -43,7 +43,7 @@ class RSVQAxBENDataModule(pl.LightningDataModule):
         tokenizer=None,
         seq_length=32,
         selected_answers=None,
-        pin_memory=None,
+        pin_memory: Optional[bool] = None,
         print_infos: bool = False,
         dataset_kwargs: Optional[Mapping] = None,
     ):

--- a/tests/extra/test_data_BEN.py
+++ b/tests/extra/test_data_BEN.py
@@ -231,23 +231,31 @@ def test_ben_dm_default(data_dir, split: str):
 @pytest.mark.parametrize("img_size", [[1], [1, 2], [1, 2, 3, 4]])
 def test_ben_dm_wrong_imagesize(data_dir, img_size):
     with pytest.raises(ValueError):
-        _ = BENDataModule(data_dir, img_size=img_size)
+        _ = BENDataModule(
+            data_dir, img_size=img_size, num_workers_dataloader=0, pin_memory=False
+        )
 
 
 @pytest.mark.parametrize("bs", [1, 2, 4, 8, 16, 32, 13, 27])
 def test_ben_dm_dataloaders(data_dir, bs):
-    dm = BENDataModule(data_dir=data_dir, batch_size=bs)
+    dm = BENDataModule(
+        data_dir=data_dir, batch_size=bs, num_workers_dataloader=0, pin_memory=False
+    )
     dataloaders_ok(dm, expected_image_shape=(bs, 12, 120, 120))
 
 
 @pytest.mark.parametrize("pi", [True, False])
 def test_dm_print_on_setup(data_dir, pi):
-    dm = BENDataModule(data_dir=data_dir, print_infos=pi)
+    dm = BENDataModule(
+        data_dir=data_dir, print_infos=pi, num_workers_dataloader=0, pin_memory=False
+    )
     dm.setup()
 
 
 def test_ben_shuffle_false(data_dir):
-    dm = BENDataModule(data_dir=data_dir, shuffle=False)
+    dm = BENDataModule(
+        data_dir=data_dir, shuffle=False, num_workers_dataloader=0, pin_memory=False
+    )
     dm.setup(None)
     # should not be equal due to transforms being random!
     assert not torch.equal(
@@ -263,7 +271,9 @@ def test_ben_shuffle_false(data_dir):
 
 
 def test_ben_shuffle_none(data_dir):
-    dm = BENDataModule(data_dir=data_dir, shuffle=None)
+    dm = BENDataModule(
+        data_dir=data_dir, shuffle=None, num_workers_dataloader=0, pin_memory=False
+    )
     dm.setup(None)
     assert not torch.equal(
         next(iter(dm.train_dataloader()))[0],
@@ -278,7 +288,9 @@ def test_ben_shuffle_none(data_dir):
 
 
 def test_ben_shuffle_true(data_dir):
-    dm = BENDataModule(data_dir=data_dir, shuffle=True)
+    dm = BENDataModule(
+        data_dir=data_dir, shuffle=True, num_workers_dataloader=0, pin_memory=False
+    )
     dm.setup(None)
     assert not torch.equal(
         next(iter(dm.train_dataloader()))[0],
@@ -293,7 +305,12 @@ def test_ben_shuffle_true(data_dir):
 
 
 def test_dm_unexposed_kwargs(data_dir):
-    dm = BENDataModule(data_dir=data_dir, dataset_kwargs={"return_patchname": True})
+    dm = BENDataModule(
+        data_dir=data_dir,
+        dataset_kwargs={"return_patchname": True},
+        num_workers_dataloader=0,
+        pin_memory=False,
+    )
     dm.setup(None)
     assert (
         len(dm.train_ds[0]) == 3

--- a/tests/extra/test_data_BEN2.py
+++ b/tests/extra/test_data_BEN2.py
@@ -230,17 +230,23 @@ def test_ben_dm_default(data_dir, split: str):
 @pytest.mark.parametrize("img_size", [[1], [1, 2], [1, 2, 3, 4]])
 def test_ben_dm_wrong_imagesize(data_dir, img_size):
     with pytest.raises(ValueError):
-        _ = BEN2DataModule(data_dir, img_size=img_size)
+        _ = BEN2DataModule(
+            data_dir, img_size=img_size, num_workers_dataloader=0, pin_memory=False
+        )
 
 
 @pytest.mark.parametrize("bs", [1, 2, 4, 8, 16, 32, 13, 27])
 def test_ben_dm_dataloaders(data_dir, bs):
-    dm = BEN2DataModule(data_dir=data_dir, batch_size=bs)
+    dm = BEN2DataModule(
+        data_dir=data_dir, batch_size=bs, num_workers_dataloader=0, pin_memory=False
+    )
     dataloaders_ok(dm, expected_image_shape=(bs, 12, 120, 120))
 
 
 def test_ben_shuffle_false(data_dir):
-    dm = BEN2DataModule(data_dir=data_dir, shuffle=False)
+    dm = BEN2DataModule(
+        data_dir=data_dir, shuffle=False, num_workers_dataloader=0, pin_memory=False
+    )
     dm.setup(None)
     # should not be equal due to transforms being random!
     assert not torch.equal(
@@ -256,7 +262,9 @@ def test_ben_shuffle_false(data_dir):
 
 
 def test_ben_shuffle_none(data_dir):
-    dm = BEN2DataModule(data_dir=data_dir, shuffle=None)
+    dm = BEN2DataModule(
+        data_dir=data_dir, shuffle=None, num_workers_dataloader=0, pin_memory=False
+    )
     dm.setup(None)
     assert not torch.equal(
         next(iter(dm.train_dataloader()))[0],
@@ -271,7 +279,9 @@ def test_ben_shuffle_none(data_dir):
 
 
 def test_ben_shuffle_true(data_dir):
-    dm = BEN2DataModule(data_dir=data_dir, shuffle=True)
+    dm = BEN2DataModule(
+        data_dir=data_dir, shuffle=True, num_workers_dataloader=0, pin_memory=False
+    )
     dm.setup(None)
     assert not torch.equal(
         next(iter(dm.train_dataloader()))[0],
@@ -286,7 +296,12 @@ def test_ben_shuffle_true(data_dir):
 
 
 def test_dm_unexposed_kwargs(data_dir):
-    dm = BEN2DataModule(data_dir=data_dir, dataset_kwargs={"return_patchname": True})
+    dm = BEN2DataModule(
+        data_dir=data_dir,
+        dataset_kwargs={"return_patchname": True},
+        num_workers_dataloader=0,
+        pin_memory=False,
+    )
     dm.setup(None)
     assert (
         len(dm.train_ds[0]) == 3
@@ -295,5 +310,7 @@ def test_dm_unexposed_kwargs(data_dir):
 
 @pytest.mark.parametrize("pi", [True, False])
 def test_dm_print_on_setup(data_dir, pi):
-    dm = BEN2DataModule(data_dir=data_dir, print_infos=pi)
+    dm = BEN2DataModule(
+        data_dir=data_dir, print_infos=pi, num_workers_dataloader=0, pin_memory=False
+    )
     dm.setup()

--- a/tests/extra/test_data_COCO-QA.py
+++ b/tests/extra/test_data_COCO-QA.py
@@ -171,7 +171,9 @@ def test_dm_default(data_dir, split: str):
 
 @pytest.mark.parametrize("bs", [1, 2, 3, 4, 16, 32])
 def test_dm_dataloader(data_dir, bs: int):
-    dm = COCOQADataModule(data_dir=data_dir, batch_size=bs)
+    dm = COCOQADataModule(
+        data_dir=data_dir, batch_size=bs, num_workers_dataloader=0, pin_memory=False
+    )
     dataloaders_ok(
         dm,
         expected_image_shape=(bs, 3, 120, 120),
@@ -181,7 +183,9 @@ def test_dm_dataloader(data_dir, bs: int):
 
 
 def test_dm_shuffle_false(data_dir):
-    dm = COCOQADataModule(data_dir=data_dir, shuffle=False)
+    dm = COCOQADataModule(
+        data_dir=data_dir, shuffle=False, num_workers_dataloader=0, pin_memory=False
+    )
 
     with warnings.catch_warnings():
         warnings.filterwarnings(
@@ -204,7 +208,9 @@ def test_dm_shuffle_false(data_dir):
 
 
 def test_dm_shuffle_none(data_dir):
-    dm = COCOQADataModule(data_dir=data_dir, shuffle=None)
+    dm = COCOQADataModule(
+        data_dir=data_dir, shuffle=None, num_workers_dataloader=0, pin_memory=False
+    )
 
     with warnings.catch_warnings():
         warnings.filterwarnings(
@@ -226,7 +232,9 @@ def test_dm_shuffle_none(data_dir):
 
 
 def test_dm_shuffle_true(data_dir):
-    dm = COCOQADataModule(data_dir=data_dir, shuffle=True)
+    dm = COCOQADataModule(
+        data_dir=data_dir, shuffle=True, num_workers_dataloader=0, pin_memory=False
+    )
 
     with warnings.catch_warnings():
         warnings.filterwarnings(

--- a/tests/extra/test_data_HRVQA.py
+++ b/tests/extra/test_data_HRVQA.py
@@ -332,7 +332,9 @@ def test_dm_default(data_dir, split: str):
 
 @pytest.mark.parametrize("bs", [1, 2, 4, 8, 16, 32, 13, 27])
 def test_dm_dataloaders_bs(data_dir, bs: int):
-    dm = HRVQADataModule(data_dir=data_dir, batch_size=bs)
+    dm = HRVQADataModule(
+        data_dir=data_dir, batch_size=bs, num_workers_dataloader=0, pin_memory=False
+    )
     dataloaders_ok(
         dm,
         expected_image_shape=(bs, 3, 1024, 1024),
@@ -344,7 +346,12 @@ def test_dm_dataloaders_bs(data_dir, bs: int):
 @pytest.mark.parametrize("img_size", [[1], [1, 2], [1, 2, 3, 4]])
 def test_dm_dataloaders_img_size(data_dir, img_size):
     with (pytest.raises(ValueError)):
-        _ = HRVQADataModule(data_dir=data_dir, img_size=img_size)
+        _ = HRVQADataModule(
+            data_dir=data_dir,
+            img_size=img_size,
+            num_workers_dataloader=0,
+            pin_memory=False,
+        )
 
 
 @pytest.mark.parametrize(
@@ -353,7 +360,11 @@ def test_dm_dataloaders_img_size(data_dir, img_size):
 )
 def test_dm_dataloaders_with_splitting(data_dir, stage, seed, div):
     dm = HRVQADataModule(
-        data_dir=data_dir, test_splitting_seed=seed, test_splitting_division=div
+        data_dir=data_dir,
+        test_splitting_seed=seed,
+        test_splitting_division=div,
+        num_workers_dataloader=0,
+        pin_memory=False,
     )
     if stage == "test" and seed is None:
         with pytest.raises(NotImplementedError):
@@ -378,7 +389,9 @@ def test_dm_dataloaders_with_splitting(data_dir, stage, seed, div):
 
 
 def test_dm_shuffle_false(data_dir):
-    dm = HRVQADataModule(data_dir=data_dir, shuffle=False)
+    dm = HRVQADataModule(
+        data_dir=data_dir, shuffle=False, num_workers_dataloader=0, pin_memory=False
+    )
     dm.setup(None)
     # should not be equal due to transforms being random!
     assert not torch.equal(
@@ -391,7 +404,9 @@ def test_dm_shuffle_false(data_dir):
 
 
 def test_dm_shuffle_none(data_dir):
-    dm = HRVQADataModule(data_dir=data_dir, shuffle=None)
+    dm = HRVQADataModule(
+        data_dir=data_dir, shuffle=None, num_workers_dataloader=0, pin_memory=False
+    )
     dm.setup(None)
     assert not torch.equal(
         next(iter(dm.train_dataloader()))[0],
@@ -403,7 +418,9 @@ def test_dm_shuffle_none(data_dir):
 
 
 def test_dm_shuffle_true(data_dir):
-    dm = HRVQADataModule(data_dir=data_dir, shuffle=True)
+    dm = HRVQADataModule(
+        data_dir=data_dir, shuffle=True, num_workers_dataloader=0, pin_memory=False
+    )
     dm.setup(None)
     assert not torch.equal(
         next(iter(dm.train_dataloader()))[0],
@@ -416,25 +433,32 @@ def test_dm_shuffle_true(data_dir):
 
 @pytest.mark.parametrize("pi", [True, False])
 def test_dm_print_on_setup(data_dir, pi):
-    dm = HRVQADataModule(data_dir=data_dir, print_infos=pi)
+    dm = HRVQADataModule(
+        data_dir=data_dir, print_infos=pi, num_workers_dataloader=0, pin_memory=False
+    )
     dm.setup()
 
 
 def test_dm_test_stage_setup(data_dir):
-    dm = HRVQADataModule(data_dir=data_dir)
+    dm = HRVQADataModule(data_dir=data_dir, num_workers_dataloader=0, pin_memory=False)
     with pytest.raises(NotImplementedError):
         dm.setup("test")
 
 
 def test_dm_predict_stage_setup(data_dir):
-    dm = HRVQADataModule(data_dir=data_dir)
+    dm = HRVQADataModule(data_dir=data_dir, num_workers_dataloader=0, pin_memory=False)
     with pytest.raises(NotImplementedError):
         dm.setup("predict")
 
 
 def test_dm_unexposed_kwargs(data_dir):
     classes = 3
-    dm = HRVQADataModule(data_dir=data_dir, dataset_kwargs={"classes": classes})
+    dm = HRVQADataModule(
+        data_dir=data_dir,
+        dataset_kwargs={"classes": classes},
+        num_workers_dataloader=0,
+        pin_memory=False,
+    )
     dm.setup(None)
     assert (
         dm.train_ds.classes == classes

--- a/tests/extra/test_data_RSVQA-HR.py
+++ b/tests/extra/test_data_RSVQA-HR.py
@@ -235,7 +235,9 @@ def test_dm_default(data_dir, split: str):
 
 @pytest.mark.parametrize("bs", [1, 2, 4, 8, 16, 32, 13, 27])
 def test_dm_dataloaders(data_dir, bs: int):
-    dm = RSVQAHRDataModule(data_dir=data_dir, batch_size=bs)
+    dm = RSVQAHRDataModule(
+        data_dir=data_dir, batch_size=bs, num_workers_dataloader=0, pin_memory=False
+    )
     dataloaders_ok(
         dm,
         expected_image_shape=(bs, 3, 256, 256),
@@ -246,12 +248,16 @@ def test_dm_dataloaders(data_dir, bs: int):
 
 @pytest.mark.parametrize("pi", [True, False])
 def test_dm_print_on_setup(data_dir, pi):
-    dm = RSVQAHRDataModule(data_dir=data_dir, print_infos=pi)
+    dm = RSVQAHRDataModule(
+        data_dir=data_dir, print_infos=pi, num_workers_dataloader=0, pin_memory=False
+    )
     dm.setup()
 
 
 def test_dm_shuffle_false(data_dir):
-    dm = RSVQAHRDataModule(data_dir=data_dir, shuffle=False)
+    dm = RSVQAHRDataModule(
+        data_dir=data_dir, shuffle=False, num_workers_dataloader=0, pin_memory=False
+    )
     dm.setup(None)
     # should not be equal due to transforms being random!
     assert not torch.equal(
@@ -267,7 +273,9 @@ def test_dm_shuffle_false(data_dir):
 
 
 def test_dm_shuffle_none(data_dir):
-    dm = RSVQAHRDataModule(data_dir=data_dir, shuffle=None)
+    dm = RSVQAHRDataModule(
+        data_dir=data_dir, shuffle=None, num_workers_dataloader=0, pin_memory=False
+    )
     dm.setup(None)
     assert not torch.equal(
         next(iter(dm.train_dataloader()))[0],
@@ -282,7 +290,9 @@ def test_dm_shuffle_none(data_dir):
 
 
 def test_dm_shuffle_true(data_dir):
-    dm = RSVQAHRDataModule(data_dir=data_dir, shuffle=True)
+    dm = RSVQAHRDataModule(
+        data_dir=data_dir, shuffle=True, num_workers_dataloader=0, pin_memory=False
+    )
     dm.setup(None)
     assert not torch.equal(
         next(iter(dm.train_dataloader()))[0],
@@ -297,9 +307,19 @@ def test_dm_shuffle_true(data_dir):
 
 
 def test_different_test_splits(data_dir):
-    dm = RSVQAHRDataModule(data_dir=data_dir, use_phili_test=False)
+    dm = RSVQAHRDataModule(
+        data_dir=data_dir,
+        use_phili_test=False,
+        num_workers_dataloader=0,
+        pin_memory=False,
+    )
     dm.setup("test")
-    dm_p = RSVQAHRDataModule(data_dir=data_dir, use_phili_test=True)
+    dm_p = RSVQAHRDataModule(
+        data_dir=data_dir,
+        use_phili_test=True,
+        num_workers_dataloader=0,
+        pin_memory=False,
+    )
     dm_p.setup("test")
 
     assert not torch.equal(
@@ -309,7 +329,12 @@ def test_different_test_splits(data_dir):
 
 def test_dm_unexposed_kwargs(data_dir):
     classes = 3
-    dm = RSVQAHRDataModule(data_dir=data_dir, dataset_kwargs={"classes": classes})
+    dm = RSVQAHRDataModule(
+        data_dir=data_dir,
+        dataset_kwargs={"classes": classes},
+        num_workers_dataloader=0,
+        pin_memory=False,
+    )
     dm.setup(None)
     assert (
         dm.train_ds.classes == classes

--- a/tests/extra/test_data_RSVQA-LR.py
+++ b/tests/extra/test_data_RSVQA-LR.py
@@ -231,7 +231,9 @@ def test_dm_default(data_dir, split: str):
 
 @pytest.mark.parametrize("bs", [1, 2, 4, 8, 16, 32, 13, 27])
 def test_dm_dataloaders(data_dir, bs: int):
-    dm = RSVQALRDataModule(data_dir=data_dir, batch_size=bs)
+    dm = RSVQALRDataModule(
+        data_dir=data_dir, batch_size=bs, num_workers_dataloader=0, pin_memory=False
+    )
     dataloaders_ok(
         dm,
         expected_image_shape=(bs, 3, 256, 256),
@@ -242,12 +244,16 @@ def test_dm_dataloaders(data_dir, bs: int):
 
 @pytest.mark.parametrize("pi", [True, False])
 def test_dm_print_on_setup(data_dir, pi):
-    dm = RSVQALRDataModule(data_dir=data_dir, print_infos=pi)
+    dm = RSVQALRDataModule(
+        data_dir=data_dir, print_infos=pi, num_workers_dataloader=0, pin_memory=False
+    )
     dm.setup()
 
 
 def test_dm_shuffle_false(data_dir):
-    dm = RSVQALRDataModule(data_dir=data_dir, shuffle=False)
+    dm = RSVQALRDataModule(
+        data_dir=data_dir, shuffle=False, num_workers_dataloader=0, pin_memory=False
+    )
     dm.setup(None)
     # should not be equal due to transforms being random!
     assert not torch.equal(
@@ -263,7 +269,9 @@ def test_dm_shuffle_false(data_dir):
 
 
 def test_dm_shuffle_none(data_dir):
-    dm = RSVQALRDataModule(data_dir=data_dir, shuffle=None)
+    dm = RSVQALRDataModule(
+        data_dir=data_dir, shuffle=None, num_workers_dataloader=0, pin_memory=False
+    )
     dm.setup(None)
     assert not torch.equal(
         next(iter(dm.train_dataloader()))[0],
@@ -278,7 +286,9 @@ def test_dm_shuffle_none(data_dir):
 
 
 def test_dm_shuffle_true(data_dir):
-    dm = RSVQALRDataModule(data_dir=data_dir, shuffle=True)
+    dm = RSVQALRDataModule(
+        data_dir=data_dir, shuffle=True, num_workers_dataloader=0, pin_memory=False
+    )
     dm.setup(None)
     assert not torch.equal(
         next(iter(dm.train_dataloader()))[0],
@@ -294,7 +304,12 @@ def test_dm_shuffle_true(data_dir):
 
 def test_dm_unexposed_kwargs(data_dir):
     classes = 3
-    dm = RSVQALRDataModule(data_dir=data_dir, dataset_kwargs={"classes": classes})
+    dm = RSVQALRDataModule(
+        data_dir=data_dir,
+        dataset_kwargs={"classes": classes},
+        num_workers_dataloader=0,
+        pin_memory=False,
+    )
     dm.setup(None)
     assert len(dm.train_ds.selected_answers) == classes, (
         f"There should only be {classes} answers, but there are "

--- a/tests/extra/test_data_RSVQAxBEN.py
+++ b/tests/extra/test_data_RSVQAxBEN.py
@@ -245,7 +245,9 @@ def test_dm_default(data_dir, split: str):
 
 @pytest.mark.parametrize("bs", [1, 2, 4, 8, 16, 32, 13, 27])
 def test_dm_dataloaders(data_dir, bs: int):
-    dm = RSVQAxBENDataModule(data_dir=data_dir, batch_size=bs)
+    dm = RSVQAxBENDataModule(
+        data_dir=data_dir, batch_size=bs, num_workers_dataloader=0, pin_memory=False
+    )
     dataloaders_ok(
         dm,
         expected_image_shape=(bs, 12, 120, 120),
@@ -256,12 +258,16 @@ def test_dm_dataloaders(data_dir, bs: int):
 
 @pytest.mark.parametrize("pi", [True, False])
 def test_dm_print_on_setup(data_dir, pi):
-    dm = RSVQAxBENDataModule(data_dir=data_dir, print_infos=pi)
+    dm = RSVQAxBENDataModule(
+        data_dir=data_dir, print_infos=pi, num_workers_dataloader=0, pin_memory=False
+    )
     dm.setup()
 
 
 def test_dm_shuffle_false(data_dir):
-    dm = RSVQAxBENDataModule(data_dir=data_dir, shuffle=False)
+    dm = RSVQAxBENDataModule(
+        data_dir=data_dir, shuffle=False, num_workers_dataloader=0, pin_memory=False
+    )
     dm.setup(None)
     # should not be equal due to transforms being random!
     assert not torch.equal(
@@ -277,7 +283,9 @@ def test_dm_shuffle_false(data_dir):
 
 
 def test_dm_shuffle_none(data_dir):
-    dm = RSVQAxBENDataModule(data_dir=data_dir, shuffle=None)
+    dm = RSVQAxBENDataModule(
+        data_dir=data_dir, shuffle=None, num_workers_dataloader=0, pin_memory=False
+    )
     dm.setup(None)
     assert not torch.equal(
         next(iter(dm.train_dataloader()))[0],
@@ -292,7 +300,9 @@ def test_dm_shuffle_none(data_dir):
 
 
 def test_dm_shuffle_true(data_dir):
-    dm = RSVQAxBENDataModule(data_dir=data_dir, shuffle=True)
+    dm = RSVQAxBENDataModule(
+        data_dir=data_dir, shuffle=True, num_workers_dataloader=0, pin_memory=False
+    )
     dm.setup(None)
     assert not torch.equal(
         next(iter(dm.train_dataloader()))[0],
@@ -308,7 +318,12 @@ def test_dm_shuffle_true(data_dir):
 
 def test_dm_unexposed_kwargs(data_dir):
     classes = 3
-    dm = RSVQAxBENDataModule(data_dir=data_dir, dataset_kwargs={"classes": classes})
+    dm = RSVQAxBENDataModule(
+        data_dir=data_dir,
+        dataset_kwargs={"classes": classes},
+        num_workers_dataloader=0,
+        pin_memory=False,
+    )
     dm.setup(None)
     assert (
         dm.train_ds.classes == classes

--- a/tests/test_il_models.py
+++ b/tests/test_il_models.py
@@ -49,7 +49,7 @@ def get_vqa_batch(
     return [v, q, a]
 
 
-@pytest.mark.parametrize("batch_size", [1, 2, 4, 8, 16, 32, 27, 13])
+@pytest.mark.parametrize("batch_size", [1, 32, 27, 13])
 def test_bs(batch_size):
     config = ConfigILM.ILMConfiguration(timm_model_name=default_image_test_model)
     x, y = get_classification_batch(
@@ -157,7 +157,7 @@ tested_timm_models_256 = [
     "swinv2_tiny_window8_256",
 ]
 
-tested_dims = [10, 1000, 256, 1024, 360, 1200]
+tested_dims = [10, 256, 1024, 360, 1200]
 
 
 def apply_timm(model: str, cls: int, bs: int, image_size: int):

--- a/tests/test_il_models.py
+++ b/tests/test_il_models.py
@@ -81,8 +81,8 @@ tested_timm_models_120 = [
     "eca_resnet33ts",
     "edgenext_xx_small",
     "efficientnet_b0",
-    "efficientnet_b4",
-    "efficientnetv2_s",
+    # "efficientnet_b4", removed in 0.4.10
+    # "efficientnetv2_s", removed in 0.4.10
     "efficientnetv2_xl",
     "gmlp_ti16_224",
     "mixer_b16_224",
@@ -91,17 +91,17 @@ tested_timm_models_120 = [
     "mobilevit_xxs",
     "mobilevitv2_050",
     "pit_ti_224",
-    "pit_ti_distilled_224",
+    # "pit_ti_distilled_224", removed in 0.4.10
     "poolformer_s12",
     "pvt_v2_b0",
-    "pvt_v2_b4",
+    # "pvt_v2_b4", removed in 0.4.10
     "res2net50_14w_8s",
     "res2next50",
     "resnest14d",
     "resnet10t",
     "resnet18",
-    "resnet34",
-    "resnet50",
+    # "resnet34",  removed in 0.4.10
+    # "resnet50",  removed in 0.4.10
     "resnetv2_50",
     "resnext26ts",
     # "semobilevit_s", removed in 0.4.0
@@ -137,14 +137,14 @@ tested_timm_models_224 = [
     "convnext_atto",
     "convnext_femto",
     "convnext_nano",
-    "convnext_pico",
-    "convnext_small",
-    "convnext_tiny",
+    # "convnext_pico", removed in 0.4.10
+    # "convnext_small", removed in 0.4.10
+    # "convnext_tiny", removed in 0.4.10
     "convnextv2_atto",
     "convnextv2_femto",
-    "convnextv2_nano",
-    "convnextv2_pico",
-    "convnextv2_small",
+    # "convnextv2_nano", removed in 0.4.10
+    # "convnextv2_pico", removed in 0.4.10
+    # "convnextv2_small", removed in 0.4.10
     "coatnext_nano_rw_224.sw_in1k",
     "maxvit_nano_rw_256.sw_in1k",
 ]
@@ -157,7 +157,7 @@ tested_timm_models_256 = [
     "swinv2_tiny_window8_256",
 ]
 
-tested_dims = [10, 100, 1000, 256, 512, 1024, 360, 1200]
+tested_dims = [10, 1000, 256, 1024, 360, 1200]
 
 
 def apply_timm(model: str, cls: int, bs: int, image_size: int):


### PR DESCRIPTION
Reduced test time by~60% (from ~5:30 min to ~2:15 min (locally)) by reducing the number of duplicate/redundant tests and moving data module tests to unpinned and single worker configurations