### PR TITLE
Updating references so that the documentation is build correctly

### DIFF
--- a/configilm/ConfigILM.py
+++ b/configilm/ConfigILM.py
@@ -281,9 +281,13 @@ class ILMConfiguration:
 
         :Default: torch.mul
 
-    :param drop_rate: Dropout and drop path rate for timm models.
+    :param drop_rate: Dropout rate for timm models.
 
         :Default: 0.2
+
+    :param drop_path_rate: Drop path rate for timm models.
+
+            :Default: 0.2
 
     :param fusion_dropout_rate: Drop rate inside all classification head layers.
 
@@ -378,6 +382,7 @@ class ILMConfiguration:
     _fusion_method: str = "torch.mul"
     _fusion_activation: str = "nn.Tanh()"
     drop_rate: Optional[float] = 0.2
+    drop_path_rate: Optional[float] = None
     use_pooler_output: bool = True
     max_sequence_length: int = 32
     load_pretrained_timm_if_available: bool = False
@@ -519,7 +524,7 @@ class ConfigILM(nn.Module):
                 "img_size": self.config.image_size,
                 "in_chans": self.config.channels,
                 "drop_rate": self.config.drop_rate,
-                "drop_path_rate": self.config.drop_rate,
+                "drop_path_rate": self.config.drop_path_rate,
                 "pretrained": self.config.load_pretrained_timm_if_available,
             }
 

--- a/configilm/extra/BENv2_utils.py
+++ b/configilm/extra/BENv2_utils.py
@@ -465,8 +465,14 @@ def resolve_data_dir(
 
     :param data_dir: current path that is suggested
     :param allow_mock: allows mock data path to be returned
+
+        :default: False
+
     :param force_mock: only mock data path will be returned. Useful for debugging with
         small data
+
+        :default: False
+
     :return: a valid dir to the dataset if data_dir was none, otherwise data_dir
     """
     return resolve_data_dir_for_ds("benv2", data_dir, allow_mock=allow_mock, force_mock=force_mock)
@@ -509,6 +515,11 @@ def band_combi_to_mean_std(bands: Iterable[str], interpolation: str = "120_neare
     BAND_COMBINATION_PREDEFINTIONS or list of bands.
 
     :param bands: a list of bandnames
+    :param interpolation: the interpolation type to use. For available types see `means.keys()`
+
+        :default: "120_nearest"
+
+
     :return: mean and standard deviation for the given combination in same order
     """
     bands = resolve_band_combi(bands)

--- a/configilm/extra/DataModules/BENv2_DataModule.py
+++ b/configilm/extra/DataModules/BENv2_DataModule.py
@@ -2,7 +2,7 @@
 Datamodule for BigEarthNet dataset. Files can be requested by contacting
 the author.
 Original Paper of Image Data:
-https://arxiv.org/abs/2105.07921
+TO BE PUBLISHED
 https://bigearth.net/
 """
 from pathlib import Path

--- a/configilm/extra/DataSets/BENv2_DataSet.py
+++ b/configilm/extra/DataSets/BENv2_DataSet.py
@@ -2,7 +2,7 @@
 Dataset for BigEarthNet dataset. Files can be requested by contacting
 the author.
 Original Paper of Image Data:
-https://arxiv.org/abs/2105.07921
+TO BE PUBLISHED
 
 https://bigearth.net/
 """

--- a/docs/API/api_datasets.md
+++ b/docs/API/api_datasets.md
@@ -7,6 +7,7 @@ See the following modules for details on DataSets and DataModules:
 
 ds/api_BEN_reader
 ds/api_ds_BENv1
+ds/api_ds_BENv2
 ds/api_ds_COCOQA
 ds/api_ds_HRVQA
 ds/api_ds_RSVQALR

--- a/docs/API/ds/api_BEN_reader.md
+++ b/docs/API/ds/api_BEN_reader.md
@@ -1,8 +1,11 @@
 (api-BEN-reader)=
-# BigEarthNetv1 Utils
+# BigEarthNet Utils
 
 :::{eval-rst}
 .. automodule:: configilm.extra.BENv1_utils
+    :members:
+    :undoc-members:
+.. automodule:: configilm.extra.BENv2_utils
     :members:
     :undoc-members:
 :::

--- a/docs/API/ds/api_ds_BENv2.md
+++ b/docs/API/ds/api_ds_BENv2.md
@@ -1,0 +1,9 @@
+(api-datasets-BENv2)=
+# BigEarthNetv2 (reBEN) DataSets and DataModules
+
+:::{eval-rst}
+.. automodule:: configilm.extra.DataSets.BENv2_DataSet
+    :members:
+.. automodule:: configilm.extra.DataModules.BENv2_DataModule
+    :members:
+:::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "configilm"
-version = "0.6.3"
+version = "0.6.4"
 description = "A state-of-the-art tool for Python developers seeking to rapidly and iteratively develop vision and language models within the [`pytorch`](https://pytorch.org/) framework"
 authors = ["Leonard Hackel <l.hackel@tu-berlin.de>"]
 readme = "README.md"

--- a/tests/test_il_models.py
+++ b/tests/test_il_models.py
@@ -501,7 +501,7 @@ def test_ilm_wrong_input_length():
         _ = model((v, q, q))
 
 
-def test_failty_config():
+def test_faulty_config():
     bs = 4
     config = ConfigILM.ILMConfiguration(
         timm_model_name=default_image_test_model,


### PR DESCRIPTION
adding drop path as its own parameter instead of re-using dropout